### PR TITLE
组件默认值配置

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "release:minor": "release-it minor",
     "release:patch": "release-it patch",
     "release:major:beta": "release-it major --preRelease=beta",
-    "release:minor:beta": "release-it minor --preRelease=beta",
+    "release:minor:beta": "release-it minor --preRelease=beta --npm.tag=next",
     "release:patch:beta": "release-it patch --preRelease=beta"
   },
   "dependencies": {

--- a/src/blank/blank.tsx
+++ b/src/blank/blank.tsx
@@ -1,6 +1,7 @@
 import React, { memo } from 'react'
 import { View } from 'react-native'
 
+import InitialValue from '../initial-value'
 import Theme from '../theme'
 
 import type { BlankProps } from './interface'
@@ -10,18 +11,19 @@ const getGapValue = (v: boolean | number, initialValue: number) => {
   return typeof v === 'boolean' ? (v ? initialValue : 0) : v
 }
 
-const Blank: React.FC<BlankProps> = ({
-  left = true,
-  right = true,
-  top = false,
-  bottom = false,
-  size = 'm',
-  type = 'margin',
+const Blank: React.FC<BlankProps> = props => {
+  let {
+    left = true,
+    right = true,
+    top = false,
+    bottom = false,
+    size = 'm',
+    type = 'margin',
 
-  children,
-  style,
-  ...restProps
-}) => {
+    children,
+    style,
+    ...restProps
+  } = InitialValue.useInitialProps('Blank', props)
   const TOKENS = Theme.useThemeTokens()
   const CV = Theme.createVar(TOKENS, varCreator)
   const defaultGap = CV[`blank_size_${size}`]

--- a/src/bottom-bar/bottom-bar.tsx
+++ b/src/bottom-bar/bottom-bar.tsx
@@ -5,22 +5,24 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 import { varCreator as varCreatorDivider } from '../divider/style'
 import { getDefaultValue } from '../helpers'
+import InitialValue from '../initial-value'
 import Theme from '../theme'
 
 import type { BottomBarProps } from './interface'
 import { varCreator } from './style'
 
-const BottomBar: React.FC<BottomBarProps> = ({
-  safeAreaInsetBottom = true,
-  backgroundColor,
-  height,
-  hidden = false,
-  keyboardShowNotRender = true,
-  divider = true,
+const BottomBar: React.FC<BottomBarProps> = props => {
+  let {
+    safeAreaInsetBottom = true,
+    backgroundColor,
+    height,
+    hidden = false,
+    keyboardShowNotRender = true,
+    divider = true,
 
-  style,
-  ...restProps
-}) => {
+    style,
+    ...restProps
+  } = InitialValue.useInitialProps('BottomBar', props)
   const { bottom } = useSafeAreaInsets()
   const TOKENS = Theme.useThemeTokens()
   const CV = Theme.createVar(TOKENS, varCreator)

--- a/src/button-bar/button-bar.tsx
+++ b/src/button-bar/button-bar.tsx
@@ -6,6 +6,7 @@ import ActionSheet from '../action-sheet'
 import { varCreator as varCreatorBlank } from '../blank/style'
 import BottomBar from '../bottom-bar'
 import Button from '../button'
+import InitialValue from '../initial-value'
 import Locale from '../locale'
 import Space from '../space'
 import Theme from '../theme'
@@ -13,16 +14,17 @@ import Theme from '../theme'
 import type { ButtonBarProps } from './interface'
 import { varCreator, styleCreator } from './style'
 
-const ButtonBar: React.FC<ButtonBarProps> = ({
-  alone = false,
-  buttons,
-  count = 4,
-  moreText,
-  blankSize = 'm',
+const ButtonBar: React.FC<ButtonBarProps> = props => {
+  const {
+    alone = false,
+    buttons,
+    count = 4,
+    moreText,
+    blankSize = 'm',
 
-  children,
-  ...restProps
-}) => {
+    children,
+    ...restProps
+  } = InitialValue.useInitialProps('ButtonBar', props)
   const locale = Locale.useLocale().ButtonBar
   const TOKENS = Theme.useThemeTokens()
   const CV = Theme.createVar(TOKENS, varCreator)

--- a/src/button/button.tsx
+++ b/src/button/button.tsx
@@ -6,6 +6,7 @@ import { Text, TouchableOpacity, StyleSheet } from 'react-native'
 
 import { getDefaultValue } from '../helpers'
 import { useDebounceFn } from '../hooks'
+import InitialValue from '../initial-value'
 import Loading from '../loading'
 import Theme from '../theme'
 
@@ -16,27 +17,28 @@ import { varCreator, styleCreator } from './style'
  * Button 按钮
  * @description 按钮用于触发一个操作，如提交表单。
  */
-const Button: React.FC<ButtonProps> = ({
-  children,
-  style,
-  text,
-  textStyle,
-  type = 'primary',
-  danger = false,
-  size = 'l',
-  hairline = false,
-  disabled = false,
-  loading = false,
-  loadingText,
-  square = false,
-  round = false,
-  renderLeftIcon,
-  color,
-  textColor,
-  onPressDebounceWait = 0,
+const Button: React.FC<ButtonProps> = props => {
+  let {
+    children,
+    style,
+    text,
+    textStyle,
+    type = 'primary',
+    danger = false,
+    size = 'l',
+    hairline = false,
+    disabled = false,
+    loading = false,
+    loadingText,
+    square = false,
+    round = false,
+    renderLeftIcon,
+    color,
+    textColor,
+    onPressDebounceWait = 0,
 
-  ...restProps
-}) => {
+    ...restProps
+  } = InitialValue.useInitialProps('Button', props)
   const TOKENS = Theme.useThemeTokens()
   const CV = Theme.createVar(TOKENS, varCreator)
   const STYLES = Theme.createStyle(CV, styleCreator)

--- a/src/cell/cell-group.tsx
+++ b/src/cell/cell-group.tsx
@@ -4,6 +4,7 @@ import { View, TouchableWithoutFeedback } from 'react-native'
 
 import Divider from '../divider'
 import { renderTextLikeJSX } from '../helpers'
+import InitialValue from '../initial-value'
 import Theme from '../theme'
 
 import type { CellGroupProps } from './interface'
@@ -13,18 +14,19 @@ import { varCreator, styleCreator } from './style'
  * CellGroup 单元格组
  * @description 一组单元格，可以设置一个标题。
  */
-const CellGroup: React.FC<React.PropsWithChildren<CellGroupProps>> = ({
-  children,
-  title,
-  extra,
-  style,
-  titleTextStyle,
-  bodyStyle,
-  bodyTopDivider = false,
-  bodyBottomDivider = false,
-  onPressTitle,
-  onPressTitleText,
-}) => {
+const CellGroup: React.FC<React.PropsWithChildren<CellGroupProps>> = props => {
+  const {
+    children,
+    title,
+    extra,
+    style,
+    titleTextStyle,
+    bodyStyle,
+    bodyTopDivider = false,
+    bodyBottomDivider = false,
+    onPressTitle,
+    onPressTitleText,
+  } = InitialValue.useInitialProps('CellGroup', props)
   const TOKENS = Theme.useThemeTokens()
   const CV = Theme.createVar(TOKENS, varCreator)
   const STYLES = Theme.createStyle(CV, styleCreator)

--- a/src/cell/cell.tsx
+++ b/src/cell/cell.tsx
@@ -5,6 +5,7 @@ import { Text, View, TouchableHighlight } from 'react-native'
 import Divider from '../divider'
 import { renderTextLikeJSX, getDefaultValue, getArrowOutline } from '../helpers'
 import { useDebounceFn } from '../hooks'
+import InitialValue from '../initial-value'
 import Theme from '../theme'
 
 import type { CellProps } from './interface'
@@ -14,36 +15,37 @@ import { varCreator, styleCreator } from './style'
  * Cell 单元格
  * @description 单元格为列表中的单个展示项。
  */
-const Cell: React.FC<CellProps> = ({
-  innerStyle,
-  title,
-  titleStyle,
-  titleTextStyle,
-  titleExtra,
-  value,
-  valueStyle,
-  valueTextStyle,
-  valueExtra,
-  contentStyle,
-  divider = true,
-  dividerLeftGap,
-  dividerRightGap,
-  isLink = false,
-  onPressLink,
-  center = false,
-  arrowDirection = 'right',
-  required = false,
-  vertical = false,
-  valueTextNumberOfLines,
-  titleTextNumberOfLines,
-  textAlign = 'right',
-  onPressDebounceWait = 0,
+const Cell: React.FC<CellProps> = props => {
+  let {
+    innerStyle,
+    title,
+    titleStyle,
+    titleTextStyle,
+    titleExtra,
+    value,
+    valueStyle,
+    valueTextStyle,
+    valueExtra,
+    contentStyle,
+    divider = true,
+    dividerLeftGap,
+    dividerRightGap,
+    isLink = false,
+    onPressLink,
+    center = false,
+    arrowDirection = 'right',
+    required = false,
+    vertical = false,
+    valueTextNumberOfLines,
+    titleTextNumberOfLines,
+    textAlign = 'right',
+    onPressDebounceWait = 0,
 
-  // 原生组件属性
-  underlayColor,
-  style,
-  ...restProps
-}) => {
+    // 原生组件属性
+    underlayColor,
+    style,
+    ...restProps
+  } = InitialValue.useInitialProps('Cell', props)
   const TOKENS = Theme.useThemeTokens()
   const CV = Theme.createVar(TOKENS, varCreator)
   const STYLES = Theme.createStyle(CV, styleCreator)

--- a/src/empty/empty.tsx
+++ b/src/empty/empty.tsx
@@ -1,6 +1,7 @@
 import isNil from 'lodash/isNil'
 import React, { memo } from 'react'
 
+import InitialValue from '../initial-value'
 import Locale from '../locale'
 import Result from '../result'
 import ResultIconEmpty from '../result/icons/result-icon-empty'
@@ -13,14 +14,15 @@ import { varCreator, styleCreator } from './style'
  * Empty 空元素
  * @description 用于填充空白数据。
  */
-const Empty: React.FC<EmptyProps> = ({
-  text,
-  style,
-  textStyle,
-  iconStyle,
-  icon,
-  full = false,
-}) => {
+const Empty: React.FC<EmptyProps> = props => {
+  const {
+    text,
+    style,
+    textStyle,
+    iconStyle,
+    icon,
+    full = false,
+  } = InitialValue.useInitialProps('Empty', props)
   const locale = Locale.useLocale().Empty
   const TOKENS = Theme.useThemeTokens()
   const CV = Theme.createVar(TOKENS, varCreator)

--- a/src/initial-value/index.ts
+++ b/src/initial-value/index.ts
@@ -1,0 +1,11 @@
+import { attachPropertiesToComponent } from '../helpers'
+
+import InitialValueProvider, {
+  useInitialValue,
+  useInitialProps,
+} from './initial-value'
+
+export default attachPropertiesToComponent(InitialValueProvider, {
+  useInitialValue,
+  useInitialProps,
+})

--- a/src/initial-value/initial-value.tsx
+++ b/src/initial-value/initial-value.tsx
@@ -1,0 +1,41 @@
+import isUndefined from 'lodash/isUndefined'
+import React, { useMemo, useContext, createContext, memo } from 'react'
+
+import type { InitialValue, InitialValueProps } from './interface'
+
+const InitialValueContext = createContext<InitialValue>({})
+
+export const useInitialValue = () => useContext(InitialValueContext)
+
+export const useInitialProps = <T,>(componentName: string, props: T): T => {
+  const initialValue = useContext(InitialValueContext)[componentName] ?? {}
+  const v: T = { ...props }
+
+  Object.keys(v).forEach(key => {
+    if (isUndefined(v[key]) && !isUndefined(initialValue[key])) {
+      v[key] = initialValue[key]
+    }
+  })
+
+  return v
+}
+
+const InitialValueProvider: React.FC<InitialValueProps> = ({
+  children,
+  initialValue,
+}) => {
+  const state = useMemo<InitialValue>(
+    () => ({
+      ...initialValue,
+    }),
+    [initialValue],
+  )
+
+  return (
+    <InitialValueContext.Provider value={state}>
+      {children}
+    </InitialValueContext.Provider>
+  )
+}
+
+export default memo<typeof InitialValueProvider>(InitialValueProvider)

--- a/src/initial-value/interface.ts
+++ b/src/initial-value/interface.ts
@@ -1,0 +1,5 @@
+export type InitialValue = Record<string, any>
+
+export interface InitialValueProps {
+  initialValue?: InitialValue
+}

--- a/src/loading/loading.tsx
+++ b/src/loading/loading.tsx
@@ -3,6 +3,7 @@ import React, { isValidElement, memo } from 'react'
 import { View, Text, StyleSheet } from 'react-native'
 
 import { getDefaultValue } from '../helpers'
+import InitialValue from '../initial-value'
 import Theme from '../theme'
 
 import type { LoadingProps } from './interface'
@@ -14,18 +15,19 @@ import { varCreator } from './style'
  * Loading 加载
  * 加载图标，用于表示加载中的过渡状态。
  */
-const Loading: React.FC<LoadingProps> = ({
-  children,
-  style,
-  textStyle,
-  size,
-  color,
-  textSize,
-  vertical = false,
-  type = 'circular',
+const Loading: React.FC<LoadingProps> = props => {
+  const {
+    children,
+    style,
+    textStyle,
+    size,
+    color,
+    textSize,
+    vertical = false,
+    type = 'circular',
 
-  ...restProps
-}) => {
+    ...restProps
+  } = InitialValue.useInitialProps('Loading', props)
   const TOKENS = Theme.useThemeTokens()
   const CV = Theme.createVar(TOKENS, varCreator)
   const ICON_COLOR = getDefaultValue(color, CV.loading_icon_color)

--- a/src/progress/progress-page.tsx
+++ b/src/progress/progress-page.tsx
@@ -5,6 +5,7 @@ import { View, Text } from 'react-native'
 import Button from '../button'
 import { getDefaultValue } from '../helpers'
 import { usePersistFn } from '../hooks'
+import InitialValue from '../initial-value'
 import Locale from '../locale'
 import Result from '../result'
 import Space from '../space'
@@ -14,17 +15,18 @@ import type { ProgressPageProps } from './interface'
 import Progress from './progress'
 import { varCreator, styleCreator } from './style'
 
-const ProgressPage: React.FC<ProgressPageProps> = ({
-  children,
-  loading: loadingOut,
-  backgroundColor,
-  defaultPercentage = 10,
-  fail,
-  failMessage,
-  failIcon,
-  onPressReload,
-  extraLoading,
-}) => {
+const ProgressPage: React.FC<ProgressPageProps> = props => {
+  let {
+    children,
+    loading: loadingOut,
+    backgroundColor,
+    defaultPercentage = 10,
+    fail,
+    failMessage,
+    failIcon,
+    onPressReload,
+    extraLoading,
+  } = InitialValue.useInitialProps('ProgressPage', props)
   const locale = Locale.useLocale().ProgressPage
   const TOKENS = Theme.useThemeTokens()
   const CV = Theme.createVar(TOKENS, varCreator)

--- a/src/provider/index.tsx
+++ b/src/provider/index.tsx
@@ -1,6 +1,7 @@
 import React, { memo } from 'react'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
 
+import InitialValue from '../initial-value'
 import Locale from '../locale'
 import Portal from '../portal'
 import Theme from '../theme'
@@ -11,14 +12,21 @@ import type { ProviderProps } from './interface'
  * 统一的配置
  * 将来 Portal 准备统一的入口，https://github.com/callstack/react-native-paper/blob/master/src/components/Portal/Portal.tsx
  */
-const Provider: React.FC<ProviderProps> = ({ children, theme, locale }) => {
+const Provider: React.FC<ProviderProps> = ({
+  children,
+  theme,
+  locale,
+  initialValue,
+}) => {
   return (
     <SafeAreaProvider>
-      <Locale locale={locale}>
-        <Theme theme={theme}>
-          <Portal.Host>{children}</Portal.Host>
-        </Theme>
-      </Locale>
+      <InitialValue initialValue={initialValue}>
+        <Locale locale={locale}>
+          <Theme theme={theme}>
+            <Portal.Host>{children}</Portal.Host>
+          </Theme>
+        </Locale>
+      </InitialValue>
     </SafeAreaProvider>
   )
 }

--- a/src/provider/interface.ts
+++ b/src/provider/interface.ts
@@ -1,6 +1,8 @@
+import type { InitialValueProps } from '../initial-value/interface'
 import type { LocaleProviderProps } from '../locale/interface'
 import type { ThemeProviderProps } from '../theme/interface'
 
 export interface ProviderProps
   extends ThemeProviderProps,
-    LocaleProviderProps {}
+    LocaleProviderProps,
+    InitialValueProps {}

--- a/src/theme/create-var.ts
+++ b/src/theme/create-var.ts
@@ -6,32 +6,32 @@ type Creator<T> = (v: TokensType) => T
 
 type KeyType = [TokensType, Creator<any>]
 
-const StyleMap: Map<KeyType, any> = new Map()
+const VarMap: Map<KeyType, any> = new Map()
 
 export const createVar = <T>(token: TokensType, creator: Creator<T>): T => {
-  let myStyle: T
+  let myVar: T
 
-  for (let [key, value] of StyleMap) {
+  for (let [key, value] of VarMap) {
     if (key[1] === creator) {
       if (key[0] === token) {
-        myStyle = value
+        myVar = value
       } else {
-        StyleMap.delete(key)
+        VarMap.delete(key)
       }
     }
   }
 
-  if (!myStyle) {
-    myStyle = creator(token)
+  if (!myVar) {
+    myVar = creator(token)
     // 变量覆盖
-    Object.keys(myStyle).forEach(field => {
+    Object.keys(myVar).forEach(field => {
       if (!isNil(token[field])) {
-        myStyle[field] = token[field]
+        myVar[field] = token[field]
       }
     })
 
-    StyleMap.set([token, creator], myStyle)
+    VarMap.set([token, creator], myVar)
   }
 
-  return myStyle
+  return myVar
 }


### PR DESCRIPTION
> 组件默认值配置。

## 目的

- 统一预设默认值，避免每个业务点手动配置
- 避免业务二次封装组件后与内部复用的组件表现不一致

## 使用

一般情况自定义默认属性。

```tsx
import React from 'react'
import { Provider, Button } from '@fruits-chain/react-native-xiaoshu'

const initialValue = {
  Button: {
    size: 'm',
    hairline: true,
    round: true,
  },
}

const App: React.FC = () => {
  return (
    <Provider initialValue={initialValue}>
      <Button text="普通按钮" type="primary" />
    </Provider>
  )
}
```

更深入、高阶替换默认元素，例如 `Empty`、`Result` 的图标。

## 适配方式

参考 [Blank](https://github.com/hjfruit/react-native-xiaoshu/pull/22/files#diff-8b71b05baf2e38a4deeb58981b6bac038e48e82cf3d23e70b65e910d75297b02)

```js
const Component = (props) => {
  const { a = '1', b = '2', ...restProps } = InitialValue.useInitialProps('Component', props)
}
```

## 已适配组件

- [x] Blank
- [x] BottomBar
- [x] Button
- [x] ButtonBar
- [x] CellGroup
- [x] Cell
- [x] Empty
- [x] Loading
- [x] ProgressPage

