### PR TITLE
chore: change bob config into the root directory

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ src/**/__fixtures__
 src/__fixtures__
 lib
 changelog.config.js
+bob.config.js

--- a/bob.config.js
+++ b/bob.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  source: 'src',
+  output: 'lib',
+  targets: [
+    'commonjs',
+    'module',
+    [
+      'typescript',
+      {
+        project: 'tsconfig.build.json',
+      },
+    ],
+  ],
+}

--- a/package.json
+++ b/package.json
@@ -143,20 +143,6 @@
       "prettier --write"
     ]
   },
-  "react-native-builder-bob": {
-    "source": "src",
-    "output": "lib",
-    "targets": [
-      "commonjs",
-      "module",
-      [
-        "typescript",
-        {
-          "project": "tsconfig.build.json"
-        }
-      ]
-    ]
-  },
   "release-it": {
     "git": {
       "commitMessage": "chore: release ${version}",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,6 +5,7 @@
     "babel.config.js",
     "metro.config.js",
     "jest.config.js",
+    "bob.config.js",
     "demo",
     "src/__fixtures__",
     "src/**/__fixtures__",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "node_modules",
     "babel.config.js",
     "metro.config.js",
-    "jest.config.js"
+    "jest.config.js",
+    "bob.config.js"
   ]
 }


### PR DESCRIPTION
- chore: change bob config into the root directory.
- 把 bob 的配置转移到根目录，方便查看构建工具配置。