### PR TITLE
feat(CheckboxGroup): 将Checkbox renderIcon属性暴露给CheckboxGroup，用于Checkbo…

### DIFF
--- a/src/checkbox/checkbox-group.tsx
+++ b/src/checkbox/checkbox-group.tsx
@@ -19,6 +19,7 @@ function CheckboxGroup<T = any>({
   activeColor,
   iconSize,
   checkboxIconLabelGap,
+  renderIcon,
   ...restProps
 }: CheckboxGroupProps<T>) {
   const [value, onChange] = useControllableValue<T | T[] | undefined | null>(
@@ -45,6 +46,7 @@ function CheckboxGroup<T = any>({
             gap={checkboxProps.gap ?? checkboxIconLabelGap}
             activeColor={checkboxProps.activeColor ?? activeColor}
             iconSize={checkboxProps.iconSize ?? iconSize}
+            renderIcon={renderIcon}
             key={`${checkboxValue}`}
             activeValue={checkboxValue}
             inactiveValue={null}

--- a/src/checkbox/interface.ts
+++ b/src/checkbox/interface.ts
@@ -127,7 +127,7 @@ export interface CheckboxProps<ActiveValueT = any, InactiveValueT = any>
 
 export interface CheckboxGroupProps<ActiveValueT = any>
   extends SpaceProps,
-    Partial<Pick<CheckboxProps, 'activeColor' | 'iconSize'>> {
+    Partial<Pick<CheckboxProps, 'activeColor' | 'iconSize' | 'renderIcon'>> {
   theme?: Partial<CheckboxTheme>
   checkboxLabelTextStyle?: CheckboxProps['labelTextStyle']
   checkboxIconLabelGap?: number

--- a/src/field/interface.ts
+++ b/src/field/interface.ts
@@ -349,6 +349,7 @@ export interface FieldCheckboxProps
       | 'activeColor'
       | 'iconSize'
       | 'deselect'
+      | 'renderIcon'
     > {}
 
 export interface FieldPasswordInputProps


### PR DESCRIPTION
使用 `CheckboxGroup` 或者 `Field.Checkbox` 想要自定义icon，比如：

```jsx
import { StyleSheet, Image, TouchableWithoutFeedback } from 'react-native'
import React, { ComponentProps } from 'react'
import { Field } from '@fruits-chain/react-native-xiaoshu'
import imgSource from '@assets'


type Props = Omit<ComponentProps<typeof Field.Checkbox>, 'renderIcon'>


const FruitFieldCheckbox: React.FC<Props> = ({ ...restProps }) => {
  return (
    <Field.Checkbox
    // @ts-ignore
      renderIcon={({ activeColor, size, active, onPress }) =>
        active ? (
            <TouchableWithoutFeedback onPress={onPress}>
                <Image style={{ width: size, height: size }} source={imgSource.fillIcon} />
            </TouchableWithoutFeedback>
        ) : (
            <TouchableWithoutFeedback onPress={onPress}>
                <Image style={{ width: size, height: size }} source={imgSource.emptyIcon} />
            </TouchableWithoutFeedback>
        )
      }
      {...restProps}
    />
  )
}

export default FruitFieldCheckbox

const styles = StyleSheet.create({})
```

renderIcon暴露给CheckboxGroup，这样便可以对CheckboxGroup也使用自定义Icon了。

PS: TypeScript提示似乎还有点问题😅