### PR TITLE
feat(Field.TextInput): 对textarea通过textInputBordered属性开放是否显示border

### DIFF
--- a/src/field/__fixtures__/text-input.tsx
+++ b/src/field/__fixtures__/text-input.tsx
@@ -71,6 +71,15 @@ const BasicFieldTextInput: React.FC = () => {
         onChange={setText1}
         divider={false}
       />
+      <Field.TextInput
+        type="textarea"
+        title="多行输入去掉边框"
+        textInputBordered={false}
+        placeholder="请输入"
+        value={text1}
+        onChange={setText1}
+        divider={false}
+      />
     </Cell.Group>
   )
 }

--- a/src/field/field-text-input.tsx
+++ b/src/field/field-text-input.tsx
@@ -30,7 +30,7 @@ const FieldTextInput: React.FC<FieldTextInputProps> = ({
 
   if (type === 'textarea') {
     textAlign = 'left'
-    textInputBordered = true
+    textInputBordered = textInputBordered ?? true
     cellProps.vertical = true
   }
 

--- a/src/field/index.md
+++ b/src/field/index.md
@@ -89,7 +89,7 @@ group:
 
 去掉 TextInputProps 的 style、bordered、size、textAlign，以，去掉 CellProps 点击事件相关属性(TouchableHighlightProps)、value、textAlign、valueTextStyle、valueTextNumberOfLines、onPressDebounceWait。
 
-> TextInput 也有 textAlign，以 TextInput 为准。如果是 textarea 会锁定竖向排版、文字左对齐、出现输入框边框。
+> TextInput 也有 textAlign，以 TextInput 为准。如果是 textarea 会锁定竖向排版、文字左对齐、出现输入框边框(可通过 textInputBordered={false}去掉边框)。
 
 | 属性名            | 描述                                                                  | 类型                          | 默认值    | 版本 |
 | :---------------- | --------------------------------------------------------------------- | ----------------------------- | --------- | ---- |


### PR DESCRIPTION
针对 `<Field.TextInput type="textarea" />` 无法关闭border的情况，通过属性 `textInputBordered` 进行设置，给用户更多可选性，默认显示border，通过下面方式隐藏border
```tsx
<Field.TextInput type="textarea" textInputBordered={false}  />
```
